### PR TITLE
Fix electron renderer failing to load

### DIFF
--- a/electronui/public/index.html
+++ b/electronui/public/index.html
@@ -8,6 +8,6 @@
 </head>
 <body>
 <div id="root"></div>
-<script type="module" src="renderer.js"></script>
+<script src="renderer.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove ES module attribute so CommonJS renderer can load

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68663be948b0832fbc24df0b3abab54d